### PR TITLE
Catch error where it set callback incorrectly

### DIFF
--- a/lib/migrant.js
+++ b/lib/migrant.js
@@ -72,7 +72,18 @@ Migrant.prototype.migrateSingle = function(mode, filename, cb) {
 
   this.log(filename, mode);
   async.series([
-    migration[mode], // run migration
+     function(cbInner) {
+      migration[mode](function(err, res) {
+        cbInner(err, res)
+        // to check if the callback set correctly on each file.
+        // if there is an error it will be written in the log file and will throw an error.
+        cbInner = function() {
+          msg = 'The callback called more than once in ' + filename
+          self.log(filename, msg, true);
+          cb(new Error(msg));
+        }
+      });
+    },
     self.meta[mode].bind(self.meta, filename) // save progress
   ], function(err, res) {
     if (err) return cb(err);

--- a/test/data/migrations/20150601-ddd.js
+++ b/test/data/migrations/20150601-ddd.js
@@ -1,0 +1,15 @@
+async = require('async')
+
+
+exports.up = function(next) {
+  async.each([1, 2, 3, 4], function(colName, cb) {
+    next(null, 'ddd: up')
+  }, next);
+}
+
+
+exports.down = function(cb) {
+  setTimeout(function() {
+    cb(null, 'ddd: down');
+  }, 10);
+}

--- a/test/migrant_test.js
+++ b/test/migrant_test.js
@@ -28,13 +28,14 @@ describe('index', function() {
     meta.flush(done)
   })
 
+
   describe('list()', function() {
 
     it('should return a list (up, 10, empty meta)', function(done) {
       meta.set(null, noon)
       m.list('up', 10, function(err, list) {
         if (err) return done(err);
-        assert.deepEqual(list, ['20141028-aaa.js', '20141030-bbb.js', '20141031-ccc.js']);
+        assert.deepEqual(list, ['20141028-aaa.js', '20141030-bbb.js', '20141031-ccc.js', '20150601-ddd.js']);
         done()
       });
     });
@@ -43,7 +44,7 @@ describe('index', function() {
       meta.set({migrations: [{filename: '20141028-aaa.js', ts: 11}]}, noon)
       m.list('up', 10, function(err, list) {
         if (err) return done(err);
-        assert.deepEqual(list, ['20141030-bbb.js', '20141031-ccc.js']);
+        assert.deepEqual(list, ['20141030-bbb.js', '20141031-ccc.js','20150601-ddd.js']);
         done()
       });
     });
@@ -127,8 +128,10 @@ describe('index', function() {
     });
   });
 
+
   describe('migrate()', function() {
     it('should migrate up', function(done) {
+      meta.set({migrations: [{filename: '20150601-ddd.js', ts: 11}]}, noon)
       m.migrate('up', 10, function(err, res) {
         if (err) return done(err);
 
@@ -146,6 +149,7 @@ describe('index', function() {
           });
 
           assert.deepEqual(migrations, [
+            '20150601-ddd.js',
             '20141028-aaa.js',
             '20141030-bbb.js',
             '20141031-ccc.js'
@@ -153,6 +157,13 @@ describe('index', function() {
           done()
         })
       })
+    });
+
+    it('should recognise double callbacks', function(done){
+      m.migrate('up', 10, function(err, res) {
+        assert.equal(err, 'Error: The callback called more than once in 20150601-ddd.js')
+        done()
+      });
     });
   });
 


### PR DESCRIPTION
#### What does this PR accomplish?
This will catch the error where it set callback incorrectly in migration scripts.

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant Trello cards?
N/A

#### Screenshots (if appropriate)
N/A