### PR TITLE
Adds support for reverting more than 1 migration

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,7 @@ var p = program
   .option('--down', 'Migrate down')
   .option('--create', 'Create empty migration')
   .option('--count', 'Migrate particular number of migration')
-  .option('--revert', 'Revert last migration')
+  .option('--revert [count]', 'Revert one or more migrations', parseInt)
   .parse(process.argv);
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ Index.prototype.run = function() {
   if (cli.create) return this.create();
 
   if (cli.revert) {
-    cli.count = 1;
+    cli.count = cli['revert'] || 1;
     cli.down = true;
     cli.up = false;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrations",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Data agnostic migrations",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
#### Details
This change makes it possible to specify a count quantity to revert more than 1 change.

It can be helpful to do this if wanting to revert a number of migrations but not all migrations like with `down`