### PR TITLE
Allow migration file extension to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ to the *migrations* executable and run it in a manual way.
 
   Options:
 
-    -h, --help  output usage information
-    --up      Migrate up
-    --down    Migrate down
-    --create  Create empty migration file
-    --count   Migrate particular number of migration
-    --revert  Revert last migration
+    -h, --help      output usage information
+    --up            Migrate up
+    --down          Migrate down
+    --create        Create empty migration file
+    --count         Migrate particular number of migration
+    --revert        Revert last migration
+    --extension     specify a file extension for the new migration file, default to 'coffee'
 ```

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,11 +6,12 @@ var p = program
   .option('--create', 'Create empty migration')
   .option('--count', 'Migrate particular number of migration')
   .option('--revert [count]', 'Revert one or more migrations', parseInt)
+  .option('--extension', 'Extension of migration file')
   .parse(process.argv);
 
 
-var keys = ['up', 'down', 'create', 'count', 'revert'];
+var keys = ['up', 'down', 'create', 'count', 'revert', 'extension'];
 for (var i = keys.length - 1; i >= 0; i--) {
   var k = keys[i];
   module.exports[k] = p[k] || process.env['npm_config_' + k];
-};
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,17 +5,38 @@ var assert = require('assert'),
   Migrant = require('./migrant');
 
 
-var noon = function() {};
+var templates = {
+  coffee: [
+    ''
+    , 'exports.up = (next) ->'
+    , '  next()'
+    , ''
+    , 'exports.down = (next) ->'
+    , '  next()'
+    , ''
+  ],
+  js: [
+    ''
+    , 'exports.up = (next) => {'
+    , '  next();'
+    , '};'
+    , ''
+    , 'exports.down = (next) => {'
+    , '  next();'
+    , '};'
+    , ''
+  ]
+};
 
 function Index(opts) {
-  assert(opts, 'options should be specified')
-  assert(opts.meta, 'meta storage should be specified')
-  assert(opts.dir, 'migrations directory should be specified')
+  assert(opts, 'options should be specified');
+  assert(opts.meta, 'meta storage should be specified');
+  assert(opts.dir, 'migrations directory should be specified');
   try {
     fs.mkdirSync(opts.dir, 0755);
   } catch (err) { /* ignore */ }
 
-  assert(fs.existsSync(opts.dir), 'migrations directory should exists')
+  assert(fs.existsSync(opts.dir), 'migrations directory should exists');
 
   opts.verbose = opts.verbose != null ? opts.verbose : true;
   this.opts = opts;
@@ -35,11 +56,11 @@ Index.prototype.run = function() {
 
   var cb = function(err) {
     if (err) {
-      console.error(err)
+      console.error(err);
       return process.exit(1);
     }
     process.exit();
-  }
+  };
 
   cli.count = cli.count || Infinity;
   if (cli.down)
@@ -50,32 +71,13 @@ Index.prototype.run = function() {
 
 
 Index.prototype.create = function() {
-  var isCoffee = !!require.extensions['.coffee'];
-
-  var template = (isCoffee ? [
-    ''
-    , 'exports.up = (next) ->'
-    , '  next()'
-    , ''
-    , 'exports.down = (next) ->'
-    , '  next()'
-    , ''
-  ] : [
-      ''
-    , 'exports.up = function(next) {'
-    , '  next();'
-    , '};'
-    , ''
-    , 'exports.down = function(next) {'
-    , '  next();'
-    , '};'
-    , ''
-  ]).join('\n');
+  var supportedExtensions = Object.keys(templates);
+  var extension = supportedExtensions.includes(cli['extension']) ? cli['extension'] : 'coffee';
+  var template = templates[extension].join('\n');
 
   var now = new Date().toISOString().substring(0, 19).replace(/-|T|:/g, ''),
-    ext = isCoffee ? '.coffee' : '.js',
     name = cli.create !== 'true' ? cli.create : 'just-another-boring-migration',
-    filename = now + '-' + name + ext,
+    filename = now + '-' + name + '.' + extension,
     filepath = path.join(this.opts.dir, filename);
 
   try {

--- a/lib/migrant.js
+++ b/lib/migrant.js
@@ -1,5 +1,4 @@
-var assert = require('assert'),
-  path = require('path'),
+var path = require('path'),
   fs = require('fs'),
   async = require('async');
 


### PR DESCRIPTION
Add a new option to specify new migration file extension, default to `.coffee`
```bash
node migrations.js --extension=js --create=test1
```

TODO:

- [x] update README