### PR TITLE
fix: fix legacy issues with package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Data agnostic migrations",
   "main": "index.js",
   "dependencies": {
-    "async": ">=0.9.0",
-    "commander": ">=2.5.0"
+    "async": "^3.1.0",
+    "commander": "^3.0.2"
   },
   "devDependencies": {
     "mocha": "^7.1.1",


### PR DESCRIPTION
Dependencies in this project uses `>=` as it was set up this way 6 years ago. Reinstall dependencies with `npm` again so that the package.json conforms to current practice of using `^` with the corresponding package-lock.json.