### PR TITLE
v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrations",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "migrations",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrations",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Data agnostic migrations",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
### Changes

- [00af23f1a33bb76a77abe0b056878c46edfdca6a] build(deps-dev): bump braces from 3.0.2 to 3.0.3
 
	


	Bumps [braces](https://github.com/micromatch/braces) from 3.0.2 to 3.0.3.


	- [Changelog](https://github.com/micromatch/braces/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/micromatch/braces/compare/3.0.2...3.0.3)


	


	---


	updated-dependencies:


	- dependency-name: braces


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [37cc03ad50a23b80ad3d70cc258ca56ad615fe93] chore(deps): update dependency mocha to ^10.5.2
 
- [8188970b2cbe0669e584637d0a6412eb76ef653e] fix(deps): update dependency commander to ^12.1.0
 
- [74fcb9307b67e6c5250743693f6d3bb6dfaffcd8] chore(deps): update dependency rimraf to ^5.0.7
 
- [76313ef8047fdc71421c834629aee47c791745e0] fix(deps): update dependency async to ^3.2.6
 
- [6f7442c68636f5658d9819d991d32efa471c252f] chore(deps): update dependency mocha to ^10.7.3
 
- [30411877541ac3856b0ecabae936a103c9300663] chore(deps): update dependency rimraf to v6
 
- [824c3a0783a4e67ef456ab215bafccf8f4bd6e69] chore: upgrade to node 22
 
- [391f1844c9b042f43e6ae79a8effa4eb65681cda] chore: run npm audit fix
 
- [aec1f31339be598e4dbfe7eea33c7968cbbd5c29] build: release minor version 1.6.0
 

### Comparison
https://github.com/Adslot/node-migrations/compare/v1.5.0...v1.6.0